### PR TITLE
Create README.md and point to other sources of the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Transistor Tester
+
+Original repository for the ubiqitous 'Transistor Tester' circuit. Other information also available on the [Mikrocontroller web page](https://www.mikrocontroller.net/articles/AVR_Transistortester).
+
+Newer firmware sources can also be found in madires' repository:
+
+* Versions from [Karl-Heinz Kübbeler](https://github.com/madires/Transistortester-Warehouse/tree/master/Firmware/k-firmware), documentation [pdf](https://github.com/madires/Transistortester-Warehouse/blob/master/Documentation/English/ttester-1.13k.pdf)
+* Versions from [Markus Reschke](https://github.com/madires/Transistortester-Warehouse/tree/master/Firmware/m-firmware), documentation [pdf](https://github.com/madires/Transistortester-Warehouse/blob/master/Documentation/English/ctester-1.54m.pdf)
+
+Updated respositories are maintained by Karl ([source](https://github.com/kubi48/TransistorTester-source), [documentation](https://github.com/kubi48/TransistorTester-documentation)) and also collated by [madires](https://github.com/madires/Transistortester-Warehouse/)


### PR DESCRIPTION
Since this repository (Mikrocontroller-net / transistortester) seems to be long un-updated; and on the web at large, it's often the most-linked to repository of firmware, I thought it would be nice if it can at least point users to more up-to-date repositories of the firmware for the Transistor Tester, and some other links.

I tried to write the most useful links I could find in a neutral way, but it's of course easily changeable.

That way, if a user searches for the source code that is making their gizmo work, and they find this repo, they can easily also find more current sources of the firmware to update to.

Cheers for all your work on the project.
